### PR TITLE
Update readme and tests with new temporary passcode and security question/answer methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ On application launch, you should check to see if your application has been conf
 
 If the application has not been configured, you can set it up using the temporary storage and finalize methods.
 
-    IMSCryptoManagerStoreTemporaryPasscode(passcode);
-    IMSCryptoManagerStoreTemporarySecurityQuestionsAndAnswers(questions, answers);
+    IMSCryptoManagerStoreTP(passcode);
+    IMSCryptoManagerStoreTSQAnswers(questions, answers);
     IMSCryptoManagerFinalize();
 
 To attempt an application unlock with either a passcode or answers to security questions, call:

--- a/SecureFoundationTests/IMSKeychainTests.m
+++ b/SecureFoundationTests/IMSKeychainTests.m
@@ -110,8 +110,8 @@
     NSData *one;
     NSData *two;
     
-    IMSCryptoManagerStoreTemporaryPasscode(passcode);
-    IMSCryptoManagerStoreTemporarySecurityQuestionsAndAnswers(questions, answers); 
+    IMSCryptoManagerStoreTP(passcode);
+    IMSCryptoManagerStoreTSQAnswers(questions, answers);
     IMSCryptoManagerFinalize();
     
     IMSCryptoManagerPurge();


### PR DESCRIPTION
I had a bit of trouble when updating to the latest version of the framework, and it turns out the API changed slightly. The README does not reflect this change, neither do the tests. Now they do!
